### PR TITLE
fix zipFIle invalide

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       max-parallel: 12
       matrix:
-        java-version: [ '8', '9', '10','11', '12','13','14', '15','16', '17' ]
+        java-version: [ '8', '9', '10','11', '12','13','14', '15','16', '17' ,'18' ,'19' ]
         os: [ 'ubuntu-latest', 'macos-latest', 'windows-latest' ]
     needs: build
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -39,7 +39,7 @@ jobs:
         java-version: [ '8', '9', '10','11', '12','13','14', '15','16', '17' ,'18' ,'19' ]
         os: [ 'ubuntu-latest', 'macos-latest', 'windows-latest' ]
     needs: build
-    runs-on: [ self-hosted ,ARM64 ,x64 ]
+    runs-on: [ ARM64 ,x64 ]
 
     steps:
 

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -39,7 +39,7 @@ jobs:
         java-version: [ '8', '9', '10','11', '12','13','14', '15','16', '17' ,'18' ,'19' ]
         os: [ 'ubuntu-latest', 'macos-latest', 'windows-latest' ]
     needs: build
-    runs-on: ${{ matrix.os }}
+    runs-on: [ self-hosted ,ARM64 ,x64 ]
 
     steps:
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Bundle signer is a command-line tool. You need to install **Java 8 or above** to
 shows how to generate signed binary file of your bundle application assuming you are using Java keystore to sign APK
 files of your application:
 ```sh  
-java -jar bundlesigner-0.1.13.jar genbin  -v --bundle app.aab --bin .  --v2-signing-enabled true --v3-signing-enabled false --ks key.jks   
+java -jar bundlesigner-0.1.14.jar genbin  -v --bundle app.aab --bin .  --v2-signing-enabled true --v3-signing-enabled false --ks key.jks   
 ```
 This generates signed digest of the provided bundle. The output of this command is a binary file that contains signed 
 digest of all APK files that can be extracted from the bundle. Signing is performed using one or more signers, each 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>ir.cafebazaar</groupId>
     <artifactId>bundlesigner</artifactId>
-    <version>0.1.13</version>
+    <version>0.1.14</version>
 
     <properties>
         <maven.compiler.target>1.8</maven.compiler.target>
@@ -91,19 +91,19 @@
         <dependency>
             <groupId>com.android.tools.build</groupId>
             <artifactId>bundletool</artifactId>
-            <version>1.11.0</version>
+            <version>1.11.2</version>
         </dependency>
 
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>3.11.0</version>
+            <version>3.10.0</version>
         </dependency>
 
         <dependency>
             <groupId>net.lingala.zip4j</groupId>
             <artifactId>zip4j</artifactId>
-            <version>2.9.0</version>
+            <version>2.11.5</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -95,12 +95,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.google.protobuf</groupId>
-            <artifactId>protobuf-java</artifactId>
-            <version>3.10.0</version>
-        </dependency>
-
-        <dependency>
             <groupId>net.lingala.zip4j</groupId>
             <artifactId>zip4j</artifactId>
             <version>2.11.5</version>


### PR DESCRIPTION
update dependencies for solving zip file problems.
bundle-tool changelog: `https://github.com/google/bundletool/releases/tag/1.11.2`
zip4j changelog: `https://github.com/srikanth-lingala/zip4j/releases/tag/v2.9.1`
and remove protobuf dependency.